### PR TITLE
Add 62256 SRAM support

### DIFF
--- a/docs/CHIP-TYPES.md
+++ b/docs/CHIP-TYPES.md
@@ -116,6 +116,7 @@ There are also some other inconsistencies between types:
 | Chip Type | Aliases | Size | Address Lines | Control Lines | Programming | Supported |
 |-----------|---------|------|---------------|---------------|-------------|-----------|
 | 6116 | 2016 | 2KB | 11 (A0-A10) | /CE (pin 18), /OE (pin 20), /WRITE (pin 21) | None | ✓ |
+| 62256 |  | 32KB | 15 (A0-A14) | /CE (pin 20), /OE (pin 22), /WRITE (pin 27) | None | ✗ |
 
 ## Pin Function Comparison
 
@@ -150,36 +151,36 @@ There are also some other inconsistencies between types:
 
 ### 28-pin Package
 
-| Pin | 23128 | 23256 | 23QL384 | 23512 | 23QL512 | 231024 | 2764 | 28C64 | 27128 | 27256 | 28C256 | 27512 |
-|-----|------|------|------|------|------|------|------|------|------|------|------|------|
-| 1 | NC | NC | NC | A15 | NC | A15 | VPP | /BUSY | VPP | VPP | A14 | A15 |
-| 2 | A12 | A12 | A12 | A12 | A12 | A12 | A12 | A12 | A12 | A12 | A12 | A12 |
-| 3 | A7 | A7 | A7 | A7 | A7 | A7 | A7 | A7 | A7 | A7 | A7 | A7 |
-| 4 | A6 | A6 | A6 | A6 | A6 | A6 | A6 | A6 | A6 | A6 | A6 | A6 |
-| 5 | A5 | A5 | A5 | A5 | A5 | A5 | A5 | A5 | A5 | A5 | A5 | A5 |
-| 6 | A4 | A4 | A4 | A4 | A4 | A4 | A4 | A4 | A4 | A4 | A4 | A4 |
-| 7 | A3 | A3 | A3 | A3 | A3 | A3 | A3 | A3 | A3 | A3 | A3 | A3 |
-| 8 | A2 | A2 | A2 | A2 | A2 | A2 | A2 | A2 | A2 | A2 | A2 | A2 |
-| 9 | A1 | A1 | A1 | A1 | A1 | A1 | A1 | A1 | A1 | A1 | A1 | A1 |
-| 10 | A0 | A0 | A0 | A0 | A0 | A0 | A0 | A0 | A0 | A0 | A0 | A0 |
-| 11 | D0 | D0 | D0 | D0 | D0 | D0 | D0 | D0 | D0 | D0 | D0 | D0 |
-| 12 | D1 | D1 | D1 | D1 | D1 | D1 | D1 | D1 | D1 | D1 | D1 | D1 |
-| 13 | D2 | D2 | D2 | D2 | D2 | D2 | D2 | D2 | D2 | D2 | D2 | D2 |
-| 14 | GND | GND | GND | GND | GND | GND | GND | GND | GND | GND | GND | GND |
-| 15 | D3 | D3 | D3 | D3 | D3 | D3 | D3 | D3 | D3 | D3 | D3 | D3 |
-| 16 | D4 | D4 | D4 | D4 | D4 | D4 | D4 | D4 | D4 | D4 | D4 | D4 |
-| 17 | D5 | D5 | D5 | D5 | D5 | D5 | D5 | D5 | D5 | D5 | D5 | D5 |
-| 18 | D6 | D6 | D6 | D6 | D6 | D6 | D6 | D6 | D6 | D6 | D6 | D6 |
-| 19 | D7 | D7 | D7 | D7 | D7 | D7 | D7 | D7 | D7 | D7 | D7 | D7 |
-| 20 | CS1 | CS1 | A15 | CS1 | A15 | CS1 | /CE | /CE | /CE | /CE | /CE | /CE+PE |
-| 21 | A10 | A10 | A10 | A10 | A10 | A10 | A10 | A10 | A10 | A10 | A10 | A10 |
-| 22 | CS2 | CS2 | CS1 | CS2 | CS1 | A16 | /OE | /OE | /OE | /OE+PE | /OE | /OE+VPP |
-| 23 | A11 | A11 | A11 | A11 | A11 | A11 | A11 | A11 | A11 | A11 | A11 | A11 |
-| 24 | A9 | A9 | A9 | A9 | A9 | A9 | A9 | A9 | A9 | A9 | A9 | A9 |
-| 25 | A8 | A8 | A8 | A8 | A8 | A8 | A8 | A8 | A8 | A8 | A8 | A8 |
-| 26 | A13 | A13 | A13 | A13 | A13 | A13 | NC | NC | A13 | A13 | A13 | A13 |
-| 27 | CS3 | A14 | A14 | A14 | A14 | A14 | /PGM | /WRITE | /PGM | A14 | /WRITE | A14 |
-| 28 | VCC | VCC | VCC | VCC | VCC | VCC | VCC | VCC | VCC | VCC | VCC | VCC |
+| Pin | 23128 | 23256 | 23QL384 | 23512 | 23QL512 | 231024 | 2764 | 28C64 | 27128 | 27256 | 28C256 | 62256 | 27512 |
+|-----|------|------|------|------|------|------|------|------|------|------|------|------|------|
+| 1 | NC | NC | NC | A15 | NC | A15 | VPP | /BUSY | VPP | VPP | A14 | A14 | A15 |
+| 2 | A12 | A12 | A12 | A12 | A12 | A12 | A12 | A12 | A12 | A12 | A12 | A12 | A12 |
+| 3 | A7 | A7 | A7 | A7 | A7 | A7 | A7 | A7 | A7 | A7 | A7 | A7 | A7 |
+| 4 | A6 | A6 | A6 | A6 | A6 | A6 | A6 | A6 | A6 | A6 | A6 | A6 | A6 |
+| 5 | A5 | A5 | A5 | A5 | A5 | A5 | A5 | A5 | A5 | A5 | A5 | A5 | A5 |
+| 6 | A4 | A4 | A4 | A4 | A4 | A4 | A4 | A4 | A4 | A4 | A4 | A4 | A4 |
+| 7 | A3 | A3 | A3 | A3 | A3 | A3 | A3 | A3 | A3 | A3 | A3 | A3 | A3 |
+| 8 | A2 | A2 | A2 | A2 | A2 | A2 | A2 | A2 | A2 | A2 | A2 | A2 | A2 |
+| 9 | A1 | A1 | A1 | A1 | A1 | A1 | A1 | A1 | A1 | A1 | A1 | A1 | A1 |
+| 10 | A0 | A0 | A0 | A0 | A0 | A0 | A0 | A0 | A0 | A0 | A0 | A0 | A0 |
+| 11 | D0 | D0 | D0 | D0 | D0 | D0 | D0 | D0 | D0 | D0 | D0 | D0 | D0 |
+| 12 | D1 | D1 | D1 | D1 | D1 | D1 | D1 | D1 | D1 | D1 | D1 | D1 | D1 |
+| 13 | D2 | D2 | D2 | D2 | D2 | D2 | D2 | D2 | D2 | D2 | D2 | D2 | D2 |
+| 14 | GND | GND | GND | GND | GND | GND | GND | GND | GND | GND | GND | GND | GND |
+| 15 | D3 | D3 | D3 | D3 | D3 | D3 | D3 | D3 | D3 | D3 | D3 | D3 | D3 |
+| 16 | D4 | D4 | D4 | D4 | D4 | D4 | D4 | D4 | D4 | D4 | D4 | D4 | D4 |
+| 17 | D5 | D5 | D5 | D5 | D5 | D5 | D5 | D5 | D5 | D5 | D5 | D5 | D5 |
+| 18 | D6 | D6 | D6 | D6 | D6 | D6 | D6 | D6 | D6 | D6 | D6 | D6 | D6 |
+| 19 | D7 | D7 | D7 | D7 | D7 | D7 | D7 | D7 | D7 | D7 | D7 | D7 | D7 |
+| 20 | CS1 | CS1 | A15 | CS1 | A15 | CS1 | /CE | /CE | /CE | /CE | /CE | /CE | /CE+PE |
+| 21 | A10 | A10 | A10 | A10 | A10 | A10 | A10 | A10 | A10 | A10 | A10 | A10 | A10 |
+| 22 | CS2 | CS2 | CS1 | CS2 | CS1 | A16 | /OE | /OE | /OE | /OE+PE | /OE | /OE | /OE+VPP |
+| 23 | A11 | A11 | A11 | A11 | A11 | A11 | A11 | A11 | A11 | A11 | A11 | A11 | A11 |
+| 24 | A9 | A9 | A9 | A9 | A9 | A9 | A9 | A9 | A9 | A9 | A9 | A9 | A9 |
+| 25 | A8 | A8 | A8 | A8 | A8 | A8 | A8 | A8 | A8 | A8 | A8 | A8 | A8 |
+| 26 | A13 | A13 | A13 | A13 | A13 | A13 | NC | NC | A13 | A13 | A13 | A13 | A13 |
+| 27 | CS3 | A14 | A14 | A14 | A14 | A14 | /PGM | /WRITE | /PGM | A14 | /WRITE | /WRITE | A14 |
+| 28 | VCC | VCC | VCC | VCC | VCC | VCC | VCC | VCC | VCC | VCC | VCC | VCC | VCC |
 
 ### 32-pin Package
 
@@ -604,6 +605,22 @@ There are also some other inconsistencies between types:
 | GND | 14 | 0V |
 
 ### 28C256 - 32KB EEPROM with fixed active-low CE/OE
+
+**Package:** 28-pin DIP  
+**Capacity:** 32768 bytes  
+**Control:** /CE, /OE, /WRITE  
+
+| Function | Pins | Notes |
+|----------|------|-------|
+| Address (A0-A14) | 10,9,8,7,6,5,4,3,25,24,21,23,2,26,1 | 15 address lines |
+| Data (D0-D7) | 11,12,13,15,16,17,18,19 | 8 data lines |
+| CE | 20 | Active low |
+| OE | 22 | Active low |
+| WRITE | 27 | Active low |
+| VCC | 28 | +5V |
+| GND | 14 | 0V |
+
+### 62256 - 32KB (32768 x 8-bit) Static RAM with fixed active-low CE/OE/WE
 
 **Package:** 28-pin DIP  
 **Capacity:** 32768 bytes  

--- a/docs/CHIP-TYPES.md
+++ b/docs/CHIP-TYPES.md
@@ -116,7 +116,7 @@ There are also some other inconsistencies between types:
 | Chip Type | Aliases | Size | Address Lines | Control Lines | Programming | Supported |
 |-----------|---------|------|---------------|---------------|-------------|-----------|
 | 6116 | 2016 | 2KB | 11 (A0-A10) | /CE (pin 18), /OE (pin 20), /WRITE (pin 21) | None | ✓ |
-| 62256 |  | 32KB | 15 (A0-A14) | /CE (pin 20), /OE (pin 22), /WRITE (pin 27) | None | ✗ |
+| 62256 |  | 32KB | 15 (A0-A14) | /CE (pin 20), /OE (pin 22), /WRITE (pin 27) | None | ✓ |
 
 ## Pin Function Comparison
 

--- a/docs/CHIP-TYPES.md
+++ b/docs/CHIP-TYPES.md
@@ -176,6 +176,10 @@ There are also some other inconsistencies between types:
 | 22 | CS2 | CS2 | CS1 | CS2 | CS1 | A16 | /OE | /OE | /OE | /OE+PE | /OE | /OE+VPP |
 | 23 | A11 | A11 | A11 | A11 | A11 | A11 | A11 | A11 | A11 | A11 | A11 | A11 |
 | 24 | A9 | A9 | A9 | A9 | A9 | A9 | A9 | A9 | A9 | A9 | A9 | A9 |
+| 25 | A8 | A8 | A8 | A8 | A8 | A8 | A8 | A8 | A8 | A8 | A8 | A8 |
+| 26 | A13 | A13 | A13 | A13 | A13 | A13 | NC | NC | A13 | A13 | A13 | A13 |
+| 27 | CS3 | A14 | A14 | A14 | A14 | A14 | /PGM | /WRITE | /PGM | A14 | /WRITE | A14 |
+| 28 | VCC | VCC | VCC | VCC | VCC | VCC | VCC | VCC | VCC | VCC | VCC | VCC |
 
 ### 32-pin Package
 
@@ -205,6 +209,14 @@ There are also some other inconsistencies between types:
 | 22 | /CE | /CE | /CE | /CE | /CE | /CE | /CE+/PGM | /CE | /CE+/PGM |
 | 23 | A10 | A10 | A10 | A10 | A10 | A10 | A10 | A10 | A10 |
 | 24 | /OE | /OE | /OE | /OE | A16 | /OE | /OE | /OE | /OE+VPP |
+| 25 | A11 | A11 | A11 | A11 | A11 | A11 | A11 | A11 | A11 |
+| 26 | A9 | A9 | A9 | A9 | A9 | A9 | A9 | A9 | A9 |
+| 27 | A8 | A8 | A8 | A8 | A8 | A8 | A8 | A8 | A8 |
+| 28 | A13 | A13 | A13 | A13 | A13 | A13 | A13 | A13 | A13 |
+| 29 | A14 | A14 | A14 | A14 | A14 | A14 | A14 | A14 | A14 |
+| 30 | CS2 | NC | /WRITE | NC | NC | A17 | A17 | A17 | A17 |
+| 31 | CS1 | NC | NC | /PGM | /PGM | /PGM | A18 | /WRITE | A18 |
+| 32 | VCC | VCC | VCC | VCC | VCC | VCC | VCC | VCC | VCC |
 
 ### 40-pin Package
 
@@ -234,6 +246,22 @@ There are also some other inconsistencies between types:
 | 22 | D4 | D4 |
 | 23 | D12 | D12 |
 | 24 | D5 | D5 |
+| 25 | D13 | D13 |
+| 26 | D6 | D6 |
+| 27 | D14 | D14 |
+| 28 | D7 | D7 |
+| 29 | A0 | A0 |
+| 30 | GND | GND |
+| 31 | /BYTE | /BYTE+VPP |
+| 32 | A17 | A17 |
+| 33 | A16 | A16 |
+| 34 | A15 | A15 |
+| 35 | A14 | A14 |
+| 36 | A13 | A13 |
+| 37 | A12 | A12 |
+| 38 | A11 | A11 |
+| 39 | A10 | A10 |
+| 40 | A9 | A9 |
 
 ## Detailed Pinouts
 

--- a/onerom-config/schema.json
+++ b/onerom-config/schema.json
@@ -320,6 +320,11 @@
                     "const": "28C256"
                 },
                 {
+                    "description": "32KB (32768 x 8-bit) Static RAM with fixed active-low CE/OE/WE - 32768 bytes, 28-pin package",
+                    "type": "string",
+                    "const": "62256"
+                },
+                {
                     "description": "A composite ROM type, serving a combined 23256 and 23128 for the Sinclair QL, with a single configured CS line and is de-selected when A14 & A15 are both high - 49152 bytes, 28-pin package",
                     "type": "string",
                     "const": "23QL384"

--- a/rust/config/build/chip/doc.rs
+++ b/rust/config/build/chip/doc.rs
@@ -299,7 +299,7 @@ fn generate_pin_comparison_table(config: &ChipTypesConfig, pin_count: u8) -> Str
     table.push('\n');
 
     // Generate row for each pin
-    for pin in 1..=24 {
+    for pin in 1..=pin_count {
         table.push_str(&format!("| {} |", pin));
         for (_, chip_type) in &roms {
             let function = get_pin_function(pin, chip_type);

--- a/rust/config/json/chip-types.json
+++ b/rust/config/json/chip-types.json
@@ -2176,6 +2176,67 @@
                     "voltage": "0V"
                 }
             ]
+        },
+        "62256": {
+            "description": "32KB (32768 x 8-bit) Static RAM with fixed active-low CE/OE/WE",
+            "function": "RAM",
+            "aliases": [],
+            "bit_modes": [8],
+            "pins": 28,
+            "size": 32768,
+            "address": [
+                10,
+                9,
+                8,
+                7,
+                6,
+                5,
+                4,
+                3,
+                25,
+                24,
+                21,
+                23,
+                2,
+                26,
+                1
+            ],
+            "data": [
+                11,
+                12,
+                13,
+                15,
+                16,
+                17,
+                18,
+                19
+            ],
+            "control": {
+                "oe": {
+                    "pin": 22,
+                    "type": "fixed_active_low"
+                },
+                "ce": {
+                    "pin": 20,
+                    "type": "fixed_active_low"
+                },
+                "write": {
+                    "pin": 27,
+                    "type": "fixed_active_low"
+                }
+            },
+            "power": [
+                {
+                    "name": "VCC",
+                    "pin": 28,
+                    "voltage": "+5V"
+                },
+                {
+                    "name": "GND",
+                    "pin": 14,
+                    "voltage": "0V"
+                }
+            ]
         }
     }
 }

--- a/rust/config/json/chip-types.json
+++ b/rust/config/json/chip-types.json
@@ -2180,6 +2180,7 @@
         "62256": {
             "description": "32KB (32768 x 8-bit) Static RAM with fixed active-low CE/OE/WE",
             "function": "RAM",
+            "supported": "0.6.13",
             "aliases": [],
             "bit_modes": [8],
             "pins": 28,

--- a/rust/gen/src/image.rs
+++ b/rust/gen/src/image.rs
@@ -638,6 +638,7 @@ impl Chip {
             ChipType::Chip23QL384 => 31,
             ChipType::Chip23C1001 => 32,
             ChipType::Chip27C200 => 33,
+            ChipType::Chip62256 => 34,
         }
     }
 }

--- a/rust/sdrr-fw-parser/src/info.rs
+++ b/rust/sdrr-fw-parser/src/info.rs
@@ -354,8 +354,12 @@ impl SdrrInfo {
                     rom_type
                 ));
             }
-            SdrrRomType::Ram6116 => {
-                return Err("RAM 6116 not supported for address mangling".into());
+            SdrrRomType::Ram6116
+            | SdrrRomType::Ram62256 => {
+                return Err(format!(
+                    "RAM type {} not supported for address mangling",
+                    rom_type
+                ));
             }
         };
 

--- a/rust/sdrr-fw-parser/src/types.rs
+++ b/rust/sdrr-fw-parser/src/types.rs
@@ -338,6 +338,11 @@ pub enum SdrrRomType {
     // 27C200
     #[deku(id = "33")]
     Rom27C200,
+
+    // 62256 (RAM)
+    #[deku(id = "34")]
+    Ram62256,
+
 }
 
 impl fmt::Display for SdrrRomType {
@@ -377,6 +382,7 @@ impl fmt::Display for SdrrRomType {
             SdrrRomType::Rom23QL384 => write!(f, "23QL384"),
             SdrrRomType::Rom23C1001 => write!(f, "23C1001"),
             SdrrRomType::Rom27C200 => write!(f, "27C200"),
+            SdrrRomType::Ram62256 => write!(f, "62256 (RAM)"),
         }
     }
 }
@@ -427,6 +433,7 @@ impl SdrrRomType {
             SdrrRomType::Rom23QL384 => 48,
             SdrrRomType::Rom23C1001 => 128,
             SdrrRomType::Rom27C200 => 256,
+            SdrrRomType::Ram62256 => 32,
         }
     }
 
@@ -467,6 +474,7 @@ impl SdrrRomType {
             SdrrRomType::Rom23QL384 => 28,
             SdrrRomType::Rom23C1001 => 32,
             SdrrRomType::Rom27C200 => 40,
+            SdrrRomType::Ram62256 => 28,
         }
     }
 
@@ -512,6 +520,7 @@ impl SdrrRomType {
             SdrrRomType::Rom23QL384 => false,
             SdrrRomType::Rom23C1001 => true,
             SdrrRomType::Rom27C200 => false,
+            SdrrRomType::Ram62256 => false,
         }
     }
 
@@ -552,6 +561,7 @@ impl SdrrRomType {
             SdrrRomType::Rom23QL384 => false,
             SdrrRomType::Rom23C1001 => false,
             SdrrRomType::Rom27C200 => false,
+            SdrrRomType::Ram62256 => false,
         }
     }
 }

--- a/sdrr/include/enums.h
+++ b/sdrr/include/enums.h
@@ -43,6 +43,7 @@ typedef enum {
     CHIP_TYPE_23QL384 = 31,        // Not a real chip, but serves the Sinclair QL's combined 23256+23128, covering $0000-$BFFF (48KB)
     CHIP_TYPE_23C1001 = 32,
     CHIP_TYPE_27C200 = 33,
+    CHIP_TYPE_62256 = 34,
     NUM_CHIP_TYPES,
     INVALID_CHIP_TYPE = 0xFF
 } sdrr_rom_type_t;
@@ -86,6 +87,7 @@ const char * const chip_type_strings[NUM_CHIP_TYPES] = {
     "23QL384",
     "23C1001",
     "27C200",
+    "62256",
 };
 _Static_assert(sizeof(chip_type_strings)/sizeof(chip_type_strings[0]) == NUM_CHIP_TYPES,
                "chip_type_strings size doesn't match NUM_CHIP_TYPES");

--- a/sdrr/include/functions.h
+++ b/sdrr/include/functions.h
@@ -96,6 +96,7 @@ extern int piorom(
 extern int pioram(
     const sdrr_info_t *info,
     sdrr_runtime_info_t *runtime,
+    const sdrr_rom_set_t *set,
     uint32_t rom_table_addr
 );
 extern ora_result_t pio_setup_address_monitor(

--- a/sdrr/src/piodma/pio.c
+++ b/sdrr/src/piodma/pio.c
@@ -23,9 +23,9 @@ int pio(
     uint32_t rom_table_addr
 ) {
     int rc;
-    if (set->roms[0]->rom_type == CHIP_TYPE_6116) {
+    if (set->roms[0]->rom_type == CHIP_TYPE_6116 || set->roms[0]->rom_type == CHIP_TYPE_62256) {
         DEBUG("PIO RAM Mode");
-        rc = pioram(info, runtime, rom_table_addr);
+        rc = pioram(info, runtime, set, rom_table_addr);
     } else {
         DEBUG("PIO ROM Mode");
         rc = piorom(info, runtime, set, rom_table_addr);

--- a/sdrr/src/piodma/pioram.c
+++ b/sdrr/src/piodma/pioram.c
@@ -830,7 +830,7 @@ static void pioram_set_gpio_func(pioram_config_t *config) {
 
     // Data pins
     for (int ii = 0; ii < 8; ii++) {
-        GPIO_CTRL(ii) = GPIO_CTRL_FUNC_PIO2;
+        GPIO_CTRL(config->data_base_pin + ii) = GPIO_CTRL_FUNC_PIO2;
     }
 }
 #else // TEST_BUILD
@@ -860,6 +860,7 @@ extern uint32_t _ram_rom_image_start[];
 int pioram(
     const sdrr_info_t *info,
     sdrr_runtime_info_t *runtime,
+    const sdrr_rom_set_t *set,
     uint32_t ram_table_addr
 ) {
     (void)info;
@@ -894,6 +895,16 @@ int pioram(
         .data_in_clkdiv_frac = 0,
     };
     
+    // The next person to add a RAM type should make this better.
+    if (set->roms[0]->rom_type == CHIP_TYPE_62256) {
+        config.read_cs_base_pin = 8;   // fire-28-d
+        config.write_cs_base_pin = 9;  // fire-28-d
+        config.write_pin = 10;          // fire-28-d
+        config.addr_base_pin = 11;      // fire-28-d
+        config.num_addr_pins = 15;      // fire-28-d
+        config.num_addr_pins = 12;      // for testing on pico2w (4k)
+    }
+
     // Bring PIOs and DMA out of reset
     APIO_ENABLE_PIOS();
     DMA_ENABLE();

--- a/sdrr/src/plugin.c
+++ b/sdrr/src/plugin.c
@@ -63,7 +63,7 @@ void ora_debug_log(const char* msg, ...) {
     do_debug_log_prefix();
     va_list args;
     va_start(args, msg);
-    do_log_v(msg, args);
+    do_log_v(msg, &args);
     va_end(args);
 #else
     (void)msg;


### PR DESCRIPTION
At present I only have a Pico 2, not a Fire 28. I have made the code correct to the best of my ability, but my test rig fails to read back data and I don't understand why. It may be a week or more until I have a Fire 28 in hand for proper testing.

This also fixes the display of pins above 24 in the generated CHIP-TYPES.md document, and a build error when using DEBUG logging.

Closes: #245 